### PR TITLE
Fix self-linked page titles and page metadata

### DIFF
--- a/content.php
+++ b/content.php
@@ -11,7 +11,7 @@
     <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
         <header>
             <?php
-            if ( is_single() ) { ?>
+            if ( is_singular() ) { ?>
             <h1 class="entry-title"><?php the_title(); ?></h1>
             <?php } else { ?>
             <h1 class="entry-title">

--- a/page/content.php
+++ b/page/content.php
@@ -11,7 +11,7 @@
     <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
         <header>
             <?php
-            if ( is_single() ) { ?>
+            if ( is_singular() ) { ?>
             <h1 class="entry-title"><?php the_title(); ?></h1>
             <?php } else { ?>
             <h1 class="entry-title">

--- a/page/functions.php
+++ b/page/functions.php
@@ -603,6 +603,15 @@ function nc_page_entry_meta_footer() {
     // Translators: used between list items, there is a space after the comma.
     $tag_list = get_the_tag_list( '', __( ', ', 'page' ) );
 
+    if ( is_page() ) {
+        if ( $tag_list ) {
+            printf( __( 'posted in %1$s and tagged %2$s.', 'page' ), $categories_list, $tag_list );
+        } elseif ( $categories_list ) {
+            printf( __( 'in %1$s.', 'page' ), $categories_list );
+        }
+        return;
+    }
+
     $author = sprintf( '<span class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></span>',
         esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
         esc_attr( sprintf( __( 'View all posts by %s', 'page' ), get_the_author() ) ),


### PR DESCRIPTION
## Summary
- Avoid self-links by treating pages as singular when rendering titles
- Skip author metadata on static pages

## Testing
- `php -l content.php`
- `php -l page/content.php`
- `php -l page/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab3df2c940832c8e2c57e320a5d81d

## Summary by Sourcery

Correct page title linking logic for pages and streamline page metadata

Bug Fixes:
- Prevent pages from self-linking their titles by switching from is_single to is_singular in templates
- Remove author metadata on static pages by short-circuiting metadata output