### PR TITLE
Enhance navigation with child page listings and sidebar fallback

### DIFF
--- a/content.php
+++ b/content.php
@@ -41,6 +41,16 @@
             if ( is_single() ) {
                 nc_page_single_post_nav();
             }
+            if ( is_page() && get_children( array( 'post_parent' => get_the_ID() ) ) ) {
+                echo '<ul class="child-page-list">';
+                wp_list_pages( array(
+                    'title_li'    => '',
+                    'child_of'    => get_the_ID(),
+                    'sort_column' => 'menu_order',
+                    'depth'       => 1,
+                ) );
+                echo '</ul>';
+            }
             ?>
         </div>
         <?php } ?>

--- a/page/content.php
+++ b/page/content.php
@@ -41,6 +41,16 @@
             if ( is_single() ) {
                 nc_page_single_post_nav();
             }
+            if ( is_page() && get_children( array( 'post_parent' => get_the_ID() ) ) ) {
+                echo '<ul class="child-page-list">';
+                wp_list_pages( array(
+                    'title_li'    => '',
+                    'child_of'    => get_the_ID(),
+                    'sort_column' => 'menu_order',
+                    'depth'       => 1,
+                ) );
+                echo '</ul>';
+            }
             ?>
         </div>
         <?php } ?>

--- a/page/header.php
+++ b/page/header.php
@@ -41,7 +41,7 @@
             <h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
             <?php } ?>
             <?php echo nc_page_get_socials_networks(); ?>
-            <?php if ( is_active_sidebar( 'sidebar' ) ) { ?><a id="pageslide-trigger" href="#sidebar">open</a><?php } ?>
+            <a id="pageslide-trigger" href="#sidebar">open</a>
         </div>
     </header>
 

--- a/page/sidebar.php
+++ b/page/sidebar.php
@@ -1,12 +1,13 @@
-<?php if ( is_active_sidebar( 'sidebar' ) || ! has_nav_menu( 'primary' ) ) { ?>
 <div id="sidebar" class="main-sidebar">
     <span class="pageslide-close">close</span>
-    <?php if ( is_active_sidebar( 'sidebar' ) ) {
+    <?php
+    if ( is_active_sidebar( 'sidebar' ) ) {
         dynamic_sidebar( 'sidebar' );
+    } else {
+        echo '<ul class="page-list">';
+        wp_list_pages( array( 'title_li' => '', 'sort_column' => 'menu_order' ) );
+        echo '</ul>';
     }
-    if ( ! has_nav_menu( 'primary' ) ) {
-        wp_page_menu( array( 'depth' => 0 ) );
-    } ?>
+    ?>
 </div>
 <div id="pageslide"></div>
-<?php } ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,12 +1,13 @@
-<?php if ( is_active_sidebar( 'sidebar' ) || ! has_nav_menu( 'primary' ) ) { ?>
 <div id="sidebar" class="main-sidebar">
     <span class="pageslide-close">close</span>
-    <?php if ( is_active_sidebar( 'sidebar' ) ) {
+    <?php
+    if ( is_active_sidebar( 'sidebar' ) ) {
         dynamic_sidebar( 'sidebar' );
+    } else {
+        echo '<ul class="page-list">';
+        wp_list_pages( array( 'title_li' => '', 'sort_column' => 'menu_order' ) );
+        echo '</ul>';
     }
-    if ( ! has_nav_menu( 'primary' ) ) {
-        wp_page_menu( array( 'depth' => 0 ) );
-    } ?>
+    ?>
 </div>
 <div id="pageslide"></div>
-<?php } ?>


### PR DESCRIPTION
## Summary
- Show a list of child pages when viewing a parent page
- Always display the sidebar trigger in the header
- Provide page list fallback when sidebar widgets are absent

## Testing
- `php -l content.php`
- `php -l page/content.php`
- `php -l page/header.php`
- `php -l page/sidebar.php`
- `php -l sidebar.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab43611520832c8b1f8cca65650fe3

## Summary by Sourcery

Enhance site navigation by showing child page listings on parent pages, ensuring the sidebar trigger is always available, and providing a fallback page list in sidebars without widgets.

New Features:
- List child pages under parent pages in the page content when applicable
- Always display the sidebar trigger link in the header
- Fallback to a hierarchical page list in the sidebar when no widgets are active