### PR TITLE
Replace broken “Older posts” link with page menu and show pages in sidebar

### DIFF
--- a/page/functions.php
+++ b/page/functions.php
@@ -504,6 +504,21 @@ function nc_page_content_nav( $html_id ) {
     global $wp_query;
 
     $html_id = esc_attr( $html_id );
+    
+    if ( isset( $wp_query->query['post_type'] ) && 'page' === $wp_query->query['post_type'] ) {
+        $pages = wp_list_pages( array(
+            'title_li' => '',
+            'echo'     => false,
+        ) );
+        if ( $pages ) : ?>
+            <nav id="<?php echo $html_id; ?>" class="navigation" role="navigation">
+                <ul class="page-list">
+                    <?php echo $pages; ?>
+                </ul>
+            </nav>
+        <?php endif;
+        return;
+    }
 
     if ( $wp_query->max_num_pages > 1 ) : ?>
         <nav id="<?php echo $html_id; ?>" class="navigation" role="navigation">

--- a/page/sidebar.php
+++ b/page/sidebar.php
@@ -3,11 +3,10 @@
     <?php
     if ( is_active_sidebar( 'sidebar' ) ) {
         dynamic_sidebar( 'sidebar' );
-    } else {
-        echo '<ul class="page-list">';
-        wp_list_pages( array( 'title_li' => '', 'sort_column' => 'menu_order' ) );
-        echo '</ul>';
     }
+    echo '<ul class="page-list">';
+    wp_list_pages( array( 'title_li' => '', 'sort_column' => 'menu_order' ) );
+    echo '</ul>';
     ?>
 </div>
 <div id="pageslide"></div>

--- a/sidebar.php
+++ b/sidebar.php
@@ -3,11 +3,10 @@
     <?php
     if ( is_active_sidebar( 'sidebar' ) ) {
         dynamic_sidebar( 'sidebar' );
-    } else {
-        echo '<ul class="page-list">';
-        wp_list_pages( array( 'title_li' => '', 'sort_column' => 'menu_order' ) );
-        echo '</ul>';
     }
+    echo '<ul class="page-list">';
+    wp_list_pages( array( 'title_li' => '', 'sort_column' => 'menu_order' ) );
+    echo '</ul>';
     ?>
 </div>
 <div id="pageslide"></div>


### PR DESCRIPTION
## Summary
- Avoid broken "Older posts" pagination when listing pages
- Show a page list navigation instead of post pagination links
- Always display page list in sidebar so Git it Write pages appear in navigation

## Testing
- `php -l page/functions.php`
- `php -l page/sidebar.php`
- `php -l sidebar.php`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab543b060c832c9681e1ed55b47538

## Summary by Sourcery

Replace broken “Older posts” pagination on page archives with a page list navigation and unconditionally show page links in the sidebar.

New Features:
- Show a page list navigation on page archives instead of post pagination.

Bug Fixes:
- Prevent broken “Older posts” pagination links when viewing pages.

Enhancements:
- Always display the page list in the sidebar regardless of active widgets.