### PR TITLE
Expose page taxonomies in sidebar

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Theme functions.
+ */
+
+// Enable categories and tags for pages.
+function nc_enable_page_taxonomies() {
+    register_taxonomy_for_object_type( 'category', 'page' );
+    register_taxonomy_for_object_type( 'post_tag', 'page' );
+}
+add_action( 'init', 'nc_enable_page_taxonomies' );
+
+// Remove the default Recent Posts widget.
+function nc_unregister_widgets() {
+    unregister_widget( 'WP_Widget_Recent_Posts' );
+}
+add_action( 'widgets_init', 'nc_unregister_widgets', 11 );

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,12 +1,37 @@
 <div id="sidebar" class="main-sidebar">
     <span class="pageslide-close">close</span>
     <?php
-    if ( is_active_sidebar( 'sidebar' ) ) {
-        dynamic_sidebar( 'sidebar' );
-    }
     echo '<ul class="page-list">';
     wp_list_pages( array( 'title_li' => '', 'sort_column' => 'menu_order' ) );
     echo '</ul>';
+
+    $categories = get_terms( array(
+        'taxonomy'   => 'category',
+        'hide_empty' => false,
+    ) );
+    if ( ! empty( $categories ) && ! is_wp_error( $categories ) ) {
+        echo '<ul class="category-list">';
+        wp_list_categories( array( 'title_li' => '', 'taxonomy' => 'category' ) );
+        echo '</ul>';
+    }
+
+    $archive_output = wp_get_archives( array(
+        'post_type' => 'page',
+        'echo'      => 0,
+    ) );
+    if ( ! empty( $archive_output ) ) {
+        echo '<ul class="archive-list">' . $archive_output . '</ul>';
+    }
+
+    $tags = get_terms( array(
+        'taxonomy'   => 'post_tag',
+        'hide_empty' => false,
+    ) );
+    if ( ! empty( $tags ) && ! is_wp_error( $tags ) ) {
+        echo '<ul class="tag-list">';
+        wp_tag_cloud( array( 'taxonomy' => 'post_tag', 'format' => 'list' ) );
+        echo '</ul>';
+    }
     ?>
 </div>
 <div id="pageslide"></div>


### PR DESCRIPTION
## Summary
- Enable categories and tags for pages and remove default Recent Posts widget
- Show page lists, categories, archives and tags directly in sidebar

## Testing
- `php -l sidebar.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab5fb97ac8832c8ad4a7cd4e7862c1

## Summary by Sourcery

Expose page taxonomies and archives in the sidebar while removing the default Recent Posts widget

New Features:
- Enable categories and tags for pages
- Display page lists, categories, page archives, and tag clouds directly in the sidebar

Enhancements:
- Unregister the default Recent Posts widget