### PR TITLE
Show categories and tags for pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,3 +15,14 @@ function nc_unregister_widgets() {
     unregister_widget( 'WP_Widget_Recent_Posts' );
 }
 add_action( 'widgets_init', 'nc_unregister_widgets', 11 );
+
+// Include pages in archive, category, and tag queries.
+function nc_include_pages_in_archives( $query ) {
+    if ( is_admin() || ! $query->is_main_query() ) {
+        return;
+    }
+    if ( $query->is_date() || $query->is_category() || $query->is_tag() ) {
+        $query->set( 'post_type', 'page' );
+    }
+}
+add_action( 'pre_get_posts', 'nc_include_pages_in_archives' );

--- a/page/functions.php
+++ b/page/functions.php
@@ -736,6 +736,17 @@ function nc_unregister_widgets() {
 }
 add_action( 'widgets_init', 'nc_unregister_widgets', 11 );
 
+// Include pages in archive, category, and tag queries.
+function nc_include_pages_in_archives( $query ) {
+    if ( is_admin() || ! $query->is_main_query() ) {
+        return;
+    }
+    if ( $query->is_date() || $query->is_category() || $query->is_tag() ) {
+        $query->set( 'post_type', 'page' );
+    }
+}
+add_action( 'pre_get_posts', 'nc_include_pages_in_archives' );
+
 // Retrieve the timestamp of the last Git commit.
 function nc_get_last_updated() {
     $dir = get_template_directory();

--- a/page/sidebar.php
+++ b/page/sidebar.php
@@ -11,7 +11,7 @@
     ) );
     if ( ! empty( $categories ) && ! is_wp_error( $categories ) ) {
         echo '<ul class="category-list">';
-        wp_list_categories( array( 'title_li' => '', 'taxonomy' => 'category' ) );
+        wp_list_categories( array( 'title_li' => '', 'taxonomy' => 'category', 'hide_empty' => 0 ) );
         echo '</ul>';
     }
 
@@ -29,7 +29,7 @@
     ) );
     if ( ! empty( $tags ) && ! is_wp_error( $tags ) ) {
         echo '<ul class="tag-list">';
-        wp_tag_cloud( array( 'taxonomy' => 'post_tag', 'format' => 'list' ) );
+        wp_tag_cloud( array( 'taxonomy' => 'post_tag', 'format' => 'list', 'hide_empty' => 0 ) );
         echo '</ul>';
     }
     ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -11,7 +11,7 @@
     ) );
     if ( ! empty( $categories ) && ! is_wp_error( $categories ) ) {
         echo '<ul class="category-list">';
-        wp_list_categories( array( 'title_li' => '', 'taxonomy' => 'category' ) );
+        wp_list_categories( array( 'title_li' => '', 'taxonomy' => 'category', 'hide_empty' => 0 ) );
         echo '</ul>';
     }
 
@@ -29,7 +29,7 @@
     ) );
     if ( ! empty( $tags ) && ! is_wp_error( $tags ) ) {
         echo '<ul class="tag-list">';
-        wp_tag_cloud( array( 'taxonomy' => 'post_tag', 'format' => 'list' ) );
+        wp_tag_cloud( array( 'taxonomy' => 'post_tag', 'format' => 'list', 'hide_empty' => 0 ) );
         echo '</ul>';
     }
     ?>

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -9,6 +9,7 @@ class FunctionsTest extends TestCase {
 
     protected function tearDown(): void {
         Monkey\tearDown();
+        \Mockery::close();
     }
 
     public function test_unregister_recent_posts_widget() {
@@ -35,5 +36,17 @@ class FunctionsTest extends TestCase {
             ->justReturn(realpath(__DIR__ . '/../page'));
         $result = nc_get_last_updated();
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T/', $result);
+    }
+
+    public function test_include_pages_in_archives_sets_post_type() {
+        Brain\Monkey\Functions\when('is_admin')->justReturn(false);
+        $query = \Mockery::mock('WP_Query');
+        $query->shouldReceive('is_main_query')->andReturn(true);
+        $query->shouldReceive('is_date')->andReturn(true);
+        $query->shouldReceive('is_category')->andReturn(false);
+        $query->shouldReceive('is_tag')->andReturn(false);
+        $query->shouldReceive('set')->with('post_type', 'page')->once();
+        nc_include_pages_in_archives($query);
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/SidebarTest.php
+++ b/tests/SidebarTest.php
@@ -25,9 +25,11 @@ class SidebarTest extends TestCase {
         $this->assertStringContainsString('archive-list', $output);
         $this->assertStringContainsString('tag-list', $output);
         $this->assertSame('category', $categoryArgs['taxonomy']);
+        $this->assertSame(0, $categoryArgs['hide_empty']);
         $this->assertSame('page', $archiveArgs['post_type']);
         $this->assertSame(0, $archiveArgs['echo']);
         $this->assertSame('post_tag', $tagArgs['taxonomy']);
         $this->assertSame('list', $tagArgs['format']);
+        $this->assertSame(0, $tagArgs['hide_empty']);
     }
 }


### PR DESCRIPTION
## Summary
- display categories and tags for pages in the sidebar
- include pages in date, category, and tag archive queries
- test sidebar taxonomy output and archive query adjustment

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ab642bd0e8832cb1d02bd39439ff99

## Summary by Sourcery

Include pages in archive, category, and tag queries and enhance sidebar templates to display all categories and tags (even empty), accompanied by new tests and cleanup in the test suite

New Features:
- Include pages in date, category, and tag archives by setting post_type to 'page' in the main query
- Always list categories and tags (including empty ones) in the sidebar by setting hide_empty to 0

Tests:
- Add unit test for nc_include_pages_in_archives to verify post_type is set for archive queries
- Update SidebarTest to assert hide_empty flag for category and tag lists

Chores:
- Close Mockery in test tearDown to ensure proper teardown