### PR TITLE
Ensure Doom button assets load on all pages

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,3 +26,20 @@ function nc_include_pages_in_archives( $query ) {
     }
 }
 add_action( 'pre_get_posts', 'nc_include_pages_in_archives' );
+
+// Enqueue assets and output markup for the procrastinate button and Doom overlay.
+function nc_enqueue_procrastinate_assets() {
+    $theme_uri = get_template_directory_uri();
+    wp_enqueue_style( 'procrastinate', $theme_uri . '/css/procrastinate.css' );
+    wp_enqueue_script( 'lottie', $theme_uri . '/js/vendor/lottie.min.js', array(), null, true );
+    wp_enqueue_script( 'dos', $theme_uri . '/js/vendor/dos.js', array(), null, true );
+    wp_enqueue_script( 'procrastinate', $theme_uri . '/js/procrastinate.js', array( 'lottie', 'dos' ), null, true );
+    wp_add_inline_script( 'procrastinate', 'var themeUrl = "' . $theme_uri . '";', 'before' );
+}
+add_action( 'wp_enqueue_scripts', 'nc_enqueue_procrastinate_assets' );
+
+function nc_render_procrastinate_markup() {
+    echo '<div id="procrastinate-btn"></div>';
+    echo '<div id="doom-overlay"><div id="doom-container"></div><button id="close-doom">Close</button></div>';
+}
+add_action( 'wp_footer', 'nc_render_procrastinate_markup' );

--- a/index.php
+++ b/index.php
@@ -54,16 +54,4 @@ if ( is_home() ) {
     wp_reset_query();
 }
 
-?>
-<link rel="stylesheet" href="<?php echo get_template_directory_uri(); ?>/css/procrastinate.css">
-<div id="procrastinate-btn"></div>
-<div id="doom-overlay">
-    <div id="doom-container"></div>
-    <button id="close-doom">Close</button>
-</div>
-    <script src="<?php echo get_template_directory_uri(); ?>/js/vendor/lottie.min.js"></script>
-    <script src="<?php echo get_template_directory_uri(); ?>/js/vendor/dos.js"></script>
-<script>var themeUrl = "<?php echo get_template_directory_uri(); ?>";</script>
-<script src="<?php echo get_template_directory_uri(); ?>/js/procrastinate.js"></script>
-<?php
 get_footer();


### PR DESCRIPTION
## Summary
- Enqueue Procrastinate styles and scripts with a global `themeUrl`
- Inject Doom button markup into the footer for consistent display across templates
- Simplify index template to rely on enqueued assets

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ac75a0b49c832c8e8851dc2d697f53