### PR TITLE
Declare blogtheme as parent for child Page theme

### DIFF
--- a/page/style.css
+++ b/page/style.css
@@ -6,6 +6,7 @@ License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: light, white, one-column, custom-background, custom-header, custom-menu, theme-options, translation-ready, right-sidebar, flexible-width
 Text Domain: page
+Template: blogtheme
 
 This theme, like WordPress, is licensed under the GPL.
 


### PR DESCRIPTION
## Summary
- declare `blogtheme` as the parent theme in `page/style.css`
- ensure DOOM overlay assets are loaded from shared parent theme directory

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68acb86e31a0832ca15d3066ad65d1e9

## Summary by Sourcery

Enable the Page theme to inherit from blogtheme by adding the Template declaration and routing DOOM overlay assets to the parent theme directory

Enhancements:
- Declare blogtheme as the parent theme for the Page child theme via the Template header
- Load DOOM overlay assets from the shared parent theme directory