### PR TITLE
Strip page prefix from DOOM overlay asset paths

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -27,26 +27,38 @@ function nc_include_pages_in_archives( $query ) {
 }
 add_action( 'pre_get_posts', 'nc_include_pages_in_archives' );
 
+// Resolve a theme asset URI, stripping any leading page/ prefix.
+function nc_theme_file_uri( $file ) {
+    $file = preg_replace( '#^page/#', '', $file );
+    return get_theme_file_uri( $file );
+}
+
+// Resolve a theme asset path, stripping any leading page/ prefix.
+function nc_theme_file_path( $file ) {
+    $file = preg_replace( '#^page/#', '', $file );
+    return get_theme_file_path( $file );
+}
+
 // Enqueue overlay assets for playing DOOM in the browser.
 function nc_enqueue_doom_overlay_assets() {
     $css_rel = 'assets/doom/overlay/doom-overlay.css';
-    $css_path = get_theme_file_path( $css_rel );
+    $css_path = nc_theme_file_path( $css_rel );
     $css_ver = file_exists( $css_path ) ? filemtime( $css_path ) : null;
 
     $js_rel = 'assets/doom/overlay/doom-overlay.js';
-    $js_path = get_theme_file_path( $js_rel );
+    $js_path = nc_theme_file_path( $js_rel );
     $js_ver = file_exists( $js_path ) ? filemtime( $js_path ) : null;
 
-    wp_enqueue_style( 'doom-overlay', get_theme_file_uri( $css_rel ), array(), $css_ver );
-    wp_enqueue_script( 'doom-overlay', get_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
+    wp_enqueue_style( 'doom-overlay', nc_theme_file_uri( $css_rel ), array(), $css_ver );
+    wp_enqueue_script( 'doom-overlay', nc_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
 
     $shareware_rel = 'assets/doom/iwads/doom1.wad';
-    $shareware_path = get_theme_file_path( $shareware_rel );
-    $shareware = file_exists( $shareware_path ) ? get_theme_file_uri( $shareware_rel ) : '';
+    $shareware_path = nc_theme_file_path( $shareware_rel );
+    $shareware = file_exists( $shareware_path ) ? nc_theme_file_uri( $shareware_rel ) : '';
 
     wp_localize_script( 'doom-overlay', 'DOOM_OVERLAY_CFG', array(
-        'engineUrl'   => get_theme_file_uri( 'assets/doom/engine/index.html' ),
-        'freedoomUrl' => get_theme_file_uri( 'assets/doom/iwads/freedoom1.wad' ),
+        'engineUrl'   => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
+        'freedoomUrl' => nc_theme_file_uri( 'assets/doom/iwads/freedoom1.wad' ),
         'sharewareUrl'=> $shareware,
     ) );
 }

--- a/page/functions.php
+++ b/page/functions.php
@@ -757,26 +757,38 @@ function nc_get_last_updated() {
     return $timestamp;
 }
 
+// Resolve a theme asset URI, stripping any leading page/ prefix.
+function nc_theme_file_uri( $file ) {
+    $file = preg_replace( '#^page/#', '', $file );
+    return get_theme_file_uri( $file );
+}
+
+// Resolve a theme asset path, stripping any leading page/ prefix.
+function nc_theme_file_path( $file ) {
+    $file = preg_replace( '#^page/#', '', $file );
+    return get_theme_file_path( $file );
+}
+
 // Enqueue overlay assets for playing DOOM in the browser.
 function nc_enqueue_doom_overlay_assets() {
     $css_rel = 'assets/doom/overlay/doom-overlay.css';
-    $css_path = get_theme_file_path( $css_rel );
+    $css_path = nc_theme_file_path( $css_rel );
     $css_ver = file_exists( $css_path ) ? filemtime( $css_path ) : null;
 
     $js_rel = 'assets/doom/overlay/doom-overlay.js';
-    $js_path = get_theme_file_path( $js_rel );
+    $js_path = nc_theme_file_path( $js_rel );
     $js_ver = file_exists( $js_path ) ? filemtime( $js_path ) : null;
 
-    wp_enqueue_style( 'doom-overlay', get_theme_file_uri( $css_rel ), array(), $css_ver );
-    wp_enqueue_script( 'doom-overlay', get_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
+    wp_enqueue_style( 'doom-overlay', nc_theme_file_uri( $css_rel ), array(), $css_ver );
+    wp_enqueue_script( 'doom-overlay', nc_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
 
     $shareware_rel = 'assets/doom/iwads/doom1.wad';
-    $shareware_path = get_theme_file_path( $shareware_rel );
-    $shareware = file_exists( $shareware_path ) ? get_theme_file_uri( $shareware_rel ) : '';
+    $shareware_path = nc_theme_file_path( $shareware_rel );
+    $shareware = file_exists( $shareware_path ) ? nc_theme_file_uri( $shareware_rel ) : '';
 
     wp_localize_script( 'doom-overlay', 'DOOM_OVERLAY_CFG', array(
-        'engineUrl'   => get_theme_file_uri( 'assets/doom/engine/index.html' ),
-        'freedoomUrl' => get_theme_file_uri( 'assets/doom/iwads/freedoom1.wad' ),
+        'engineUrl'   => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
+        'freedoomUrl' => nc_theme_file_uri( 'assets/doom/iwads/freedoom1.wad' ),
         'sharewareUrl'=> $shareware,
     ) );
 }

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -58,6 +58,16 @@ class DoomOverlayTest extends TestCase {
         $this->assertStringContainsString('iframe id="doom-frame"', $out);
     }
 
+    public function test_theme_file_helpers_strip_page_prefix() {
+        Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn('http://example.com/theme/assets/doom/overlay/doom-overlay.css');
+        $uri = nc_theme_file_uri('page/assets/doom/overlay/doom-overlay.css');
+        $this->assertSame('http://example.com/theme/assets/doom/overlay/doom-overlay.css', $uri);
+
+        Monkey\Functions\expect('get_theme_file_path')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn('/path/theme/assets/doom/overlay/doom-overlay.css');
+        $path = nc_theme_file_path('page/assets/doom/overlay/doom-overlay.css');
+        $this->assertSame('/path/theme/assets/doom/overlay/doom-overlay.css', $path);
+    }
+
     public function test_download_shareware_wad_extracts_file() {
         $tempDir = sys_get_temp_dir() . '/wadtest_' . uniqid();
         mkdir($tempDir);


### PR DESCRIPTION
## Summary
- Add helper wrappers for `get_theme_file_uri` and `get_theme_file_path` that strip any leading `page/`
- Use helpers when enqueueing DOOM overlay assets to avoid `page` in URLs
- Test helpers to ensure `page/` prefix is removed

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68acb86e31a0832ca15d3066ad65d1e9

## Summary by Sourcery

Introduce wrapper functions to remove leading "page/" prefix from theme asset URIs and file paths, update DOOM overlay asset enqueue logic to use these wrappers, and add tests to verify the prefix removal.

New Features:
- Add nc_theme_file_uri helper to strip leading "page/" prefix and resolve theme asset URIs
- Add nc_theme_file_path helper to strip leading "page/" prefix and resolve theme asset file paths

Enhancements:
- Update DOOM overlay asset enqueueing to use nc_theme_file_uri and nc_theme_file_path instead of direct theme file functions

Tests:
- Add unit tests to verify that nc_theme_file_uri and nc_theme_file_path correctly remove the "page/" prefix