### PR TITLE
Fix asset URL generation to drop legacy page prefix

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The template for displaying the footer.
+ *
+ * Contains footer content and the closing of the
+ * #main and #page div elements.
+ */
+?>
+    </div>
+</div>
+<nav class="site-navigation" role="navigation">
+    <?php wp_nav_menu( array(
+        'theme_location' => 'primary',
+        'container'      => false,
+        'menu_class'     => 'site-wrapper',
+        'items_wrap'     => '<ul class="%2$s">%3$s</ul>',
+        'depth'          => 0,
+        'fallback_cb'    => false
+    ) ); ?>
+</nav>
+<footer class="site-footer" role="contentinfo">
+    <div class="site-wrapper">
+        <p class="last-updated">Last updated: <?php echo esc_html( nc_get_last_updated() ); ?></p>
+    </div>
+</footer>
+<?php get_sidebar(); ?>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -27,14 +27,26 @@ function nc_include_pages_in_archives( $query ) {
 }
 add_action( 'pre_get_posts', 'nc_include_pages_in_archives' );
 
+// Get timestamp of last git commit for theme directory.
+function nc_get_last_updated() {
+    $dir = get_template_directory();
+    $timestamp = trim( shell_exec( 'git -C ' . escapeshellarg( $dir ) . ' log -1 --format=%cI' ) );
+    if ( empty( $timestamp ) ) {
+        $timestamp = gmdate( 'c' );
+    }
+    return $timestamp;
+}
+
 // Resolve a theme asset URI, stripping any leading page/ prefix.
 function nc_theme_file_uri( $file ) {
+    $file = ltrim( $file, '/' );
     $file = preg_replace( '#^page/#', '', $file );
     return get_theme_file_uri( $file );
 }
 
 // Resolve a theme asset path, stripping any leading page/ prefix.
 function nc_theme_file_path( $file ) {
+    $file = ltrim( $file, '/' );
     $file = preg_replace( '#^page/#', '', $file );
     return get_theme_file_path( $file );
 }

--- a/page/functions.php
+++ b/page/functions.php
@@ -759,12 +759,14 @@ function nc_get_last_updated() {
 
 // Resolve a theme asset URI, stripping any leading page/ prefix.
 function nc_theme_file_uri( $file ) {
+    $file = ltrim( $file, '/' );
     $file = preg_replace( '#^page/#', '', $file );
     return get_theme_file_uri( $file );
 }
 
 // Resolve a theme asset path, stripping any leading page/ prefix.
 function nc_theme_file_path( $file ) {
+    $file = ltrim( $file, '/' );
     $file = preg_replace( '#^page/#', '', $file );
     return get_theme_file_path( $file );
 }

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -2,7 +2,6 @@
 use PHPUnit\Framework\TestCase;
 use Brain\Monkey;
 
-require_once __DIR__ . '/../page/functions.php';
 require_once __DIR__ . '/../tools/download-shareware-wad.php';
 
 class DoomOverlayTest extends TestCase {
@@ -59,13 +58,17 @@ class DoomOverlayTest extends TestCase {
     }
 
     public function test_theme_file_helpers_resolve_paths() {
-        Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn('http://example.com/theme/assets/doom/overlay/doom-overlay.css');
-        $uri = nc_theme_file_uri('assets/doom/overlay/doom-overlay.css');
-        $this->assertSame('http://example.com/theme/assets/doom/overlay/doom-overlay.css', $uri);
+        Monkey\Functions\expect('get_theme_file_uri')->twice()->with('assets/doom/overlay/doom-overlay.css')->andReturn('http://example.com/theme/assets/doom/overlay/doom-overlay.css');
+        $uri1 = nc_theme_file_uri('page/assets/doom/overlay/doom-overlay.css');
+        $this->assertSame('http://example.com/theme/assets/doom/overlay/doom-overlay.css', $uri1);
+        $uri2 = nc_theme_file_uri('/page/assets/doom/overlay/doom-overlay.css');
+        $this->assertSame('http://example.com/theme/assets/doom/overlay/doom-overlay.css', $uri2);
 
-        Monkey\Functions\expect('get_theme_file_path')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn('/path/theme/assets/doom/overlay/doom-overlay.css');
-        $path = nc_theme_file_path('assets/doom/overlay/doom-overlay.css');
-        $this->assertSame('/path/theme/assets/doom/overlay/doom-overlay.css', $path);
+        Monkey\Functions\expect('get_theme_file_path')->twice()->with('assets/doom/overlay/doom-overlay.css')->andReturn('/path/theme/assets/doom/overlay/doom-overlay.css');
+        $path1 = nc_theme_file_path('page/assets/doom/overlay/doom-overlay.css');
+        $this->assertSame('/path/theme/assets/doom/overlay/doom-overlay.css', $path1);
+        $path2 = nc_theme_file_path('/page/assets/doom/overlay/doom-overlay.css');
+        $this->assertSame('/path/theme/assets/doom/overlay/doom-overlay.css', $path2);
     }
 
     public function test_download_shareware_wad_extracts_file() {

--- a/tests/FooterTest.php
+++ b/tests/FooterTest.php
@@ -8,12 +8,12 @@ class FooterTest extends TestCase {
 
     public function test_footer_shows_last_updated() {
         Brain\Monkey\Functions\when('wp_nav_menu')->justReturn('');
-        Brain\Monkey\Functions\when('get_template_directory')->justReturn(realpath(__DIR__ . '/../page'));
+        Brain\Monkey\Functions\when('get_template_directory')->justReturn(realpath(__DIR__ . '/..'));
         Brain\Monkey\Functions\when('get_sidebar')->justReturn('');
         Brain\Monkey\Functions\when('wp_footer')->justReturn('');
 
         ob_start();
-        include __DIR__ . '/../page/footer.php';
+        include __DIR__ . '/../footer.php';
         $output = ob_get_clean();
         $this->assertMatchesRegularExpression('/Last updated: \d{4}-\d{2}-\d{2}T/', $output);
     }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -33,7 +33,7 @@ class FunctionsTest extends TestCase {
 
     public function test_get_last_updated_uses_git() {
         Brain\Monkey\Functions\when('get_template_directory')
-            ->justReturn(realpath(__DIR__ . '/../page'));
+            ->justReturn(realpath(__DIR__ . '/..'));
         $result = nc_get_last_updated();
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T/', $result);
     }

--- a/tests/SidebarTest.php
+++ b/tests/SidebarTest.php
@@ -18,7 +18,7 @@ class SidebarTest extends TestCase {
         Brain\Monkey\Functions\when('wp_tag_cloud')->alias(function($args) use (&$tagArgs){ $tagArgs = $args; return '<li>tag</li>'; });
 
         ob_start();
-        include __DIR__ . '/../page/sidebar.php';
+        include __DIR__ . '/../sidebar.php';
         $output = ob_get_clean();
         $this->assertStringNotContainsString('Recent Posts', $output);
         $this->assertStringContainsString('category-list', $output);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,4 +16,4 @@ if (!function_exists('esc_html')) {
         return $text;
     }
 }
-require_once __DIR__ . '/../page/functions.php';
+require_once __DIR__ . '/../functions.php';


### PR DESCRIPTION
## Summary
- ensure theme asset helpers trim leading slashes and remove obsolete `page/` segment
- expose `nc_get_last_updated` and add a footer template that uses it
- update tests to cover page-prefixed paths and load root templates

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68acd8dc38c8832c8310e8cd7dd4bb6e