### PR TITLE
Fix DOOM overlay asset paths

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -66,11 +66,11 @@ function nc_theme_file_path( $file ) {
 
 // Enqueue overlay assets for playing DOOM in the browser.
 function nc_enqueue_doom_overlay_assets() {
-    $css_rel = 'page/assets/doom/overlay/doom-overlay.css';
+    $css_rel = 'assets/doom/overlay/doom-overlay.css';
     $css_path = nc_theme_file_path( $css_rel );
     $css_ver = file_exists( $css_path ) ? filemtime( $css_path ) : null;
 
-    $js_rel = 'page/assets/doom/overlay/doom-overlay.js';
+    $js_rel = 'assets/doom/overlay/doom-overlay.js';
     $js_path = nc_theme_file_path( $js_rel );
     $js_ver = file_exists( $js_path ) ? filemtime( $js_path ) : null;
 
@@ -78,7 +78,7 @@ function nc_enqueue_doom_overlay_assets() {
     wp_enqueue_script( 'doom-overlay', nc_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
 
     wp_localize_script( 'doom-overlay', 'DOOM_OVERLAY_CFG', array(
-        'engineUrl'   => nc_theme_file_uri( 'page/assets/doom/engine/index.html' ),
+        'engineUrl'   => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
         'freedoomUrl' => NC_FREEDOOM_URL,
         'sharewareUrl'=> NC_SHAREWARE_URL,
     ) );

--- a/page/functions.php
+++ b/page/functions.php
@@ -786,11 +786,11 @@ function nc_theme_file_path( $file ) {
 
 // Enqueue overlay assets for playing DOOM in the browser.
 function nc_enqueue_doom_overlay_assets() {
-    $css_rel = 'page/assets/doom/overlay/doom-overlay.css';
+    $css_rel = 'assets/doom/overlay/doom-overlay.css';
     $css_path = nc_theme_file_path( $css_rel );
     $css_ver = file_exists( $css_path ) ? filemtime( $css_path ) : null;
 
-    $js_rel = 'page/assets/doom/overlay/doom-overlay.js';
+    $js_rel = 'assets/doom/overlay/doom-overlay.js';
     $js_path = nc_theme_file_path( $js_rel );
     $js_ver = file_exists( $js_path ) ? filemtime( $js_path ) : null;
 
@@ -798,7 +798,7 @@ function nc_enqueue_doom_overlay_assets() {
     wp_enqueue_script( 'doom-overlay', nc_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
 
     wp_localize_script( 'doom-overlay', 'DOOM_OVERLAY_CFG', array(
-        'engineUrl'   => nc_theme_file_uri( 'page/assets/doom/engine/index.html' ),
+        'engineUrl'   => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
         'freedoomUrl' => NC_FREEDOOM_URL,
         'sharewareUrl'=> NC_SHAREWARE_URL,
     ) );

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -59,14 +59,14 @@ class DoomOverlayTest extends TestCase {
     }
 
     public function test_theme_file_helpers_resolve_paths() {
-        Monkey\Functions\expect('get_stylesheet_directory')->times(4)->andReturn('/path/theme');
-        Monkey\Functions\expect('get_theme_file_uri')->twice()->with('page/assets/doom/overlay/doom-overlay.css')->andReturn('http://example.com/theme/page/assets/doom/overlay/doom-overlay.css');
+        Monkey\Functions\expect('get_stylesheet_directory')->times(4)->andReturn('/path/theme/page');
+        Monkey\Functions\expect('get_theme_file_uri')->twice()->with('assets/doom/overlay/doom-overlay.css')->andReturn('http://example.com/theme/page/assets/doom/overlay/doom-overlay.css');
         $uri1 = nc_theme_file_uri('page/assets/doom/overlay/doom-overlay.css');
         $this->assertSame('http://example.com/theme/page/assets/doom/overlay/doom-overlay.css', $uri1);
         $uri2 = nc_theme_file_uri('/page/assets/doom/overlay/doom-overlay.css');
         $this->assertSame('http://example.com/theme/page/assets/doom/overlay/doom-overlay.css', $uri2);
 
-        Monkey\Functions\expect('get_theme_file_path')->twice()->with('page/assets/doom/overlay/doom-overlay.css')->andReturn('/path/theme/page/assets/doom/overlay/doom-overlay.css');
+        Monkey\Functions\expect('get_theme_file_path')->twice()->with('assets/doom/overlay/doom-overlay.css')->andReturn('/path/theme/page/assets/doom/overlay/doom-overlay.css');
         $path1 = nc_theme_file_path('page/assets/doom/overlay/doom-overlay.css');
         $this->assertSame('/path/theme/page/assets/doom/overlay/doom-overlay.css', $path1);
         $path2 = nc_theme_file_path('/page/assets/doom/overlay/doom-overlay.css');


### PR DESCRIPTION
## Summary
- resolve DOOM overlay links by deriving paths via `get_theme_file_uri()`
- update helper tests for assets living in `page` subdirectory

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ace6f8bcf8832cbcfde2536ac9cab3