### PR TITLE
Fix typo: procrastinate

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -89,7 +89,7 @@ add_action( 'wp_enqueue_scripts', 'nc_enqueue_doom_overlay_assets' );
 function nc_render_doom_overlay() {
     ?>
     <div id="doom-procrastinate">
-        <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap">Procrestenate <span class="doom-here">here!</span></button>
+        <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap">Procrastinate <span class="doom-here">here!</span></button>
 
         <div id="doom-frame-wrap" hidden>
             <div class="doom-bar">

--- a/page/functions.php
+++ b/page/functions.php
@@ -809,7 +809,7 @@ add_action( 'wp_enqueue_scripts', 'nc_enqueue_doom_overlay_assets' );
 function nc_render_doom_overlay() {
     ?>
     <div id="doom-procrastinate">
-        <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap">Procrestenate <span class="doom-here">here!</span></button>
+        <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap">Procrastinate <span class="doom-here">here!</span></button>
 
         <div id="doom-frame-wrap" hidden>
             <div class="doom-bar">

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -54,7 +54,7 @@ class DoomOverlayTest extends TestCase {
         $out = ob_get_clean();
         $this->assertStringContainsString('id="doom-procrastinate"', $out);
         $this->assertStringContainsString('iframe id="doom-frame"', $out);
-        $this->assertStringContainsString('Procrestenate', $out);
+        $this->assertStringContainsString('Procrastinate', $out);
         $this->assertStringContainsString('class="doom-here"', $out);
     }
 


### PR DESCRIPTION
## Summary
- fix "Procrestenate" typo in DOOM overlay button and test

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68acea9075d4832cb2d783eb4bf44371

## Summary by Sourcery

Correct the spelling of the DOOM overlay button label and update the corresponding test to match.

Bug Fixes:
- Fix typo in overlay button text from “Procrestenate” to “Procrastinate”.

Tests:
- Update test assertion to expect “Procrastinate” in the rendered output.