### PR TITLE
Guard against missing DOOM elements

### DIFF
--- a/js/procrastinate.js
+++ b/js/procrastinate.js
@@ -12,16 +12,22 @@ document.addEventListener('DOMContentLoaded', function () {
 
   btn.addEventListener('click', function () {
     var overlay = document.getElementById('doom-overlay');
+    var container = document.getElementById('doom-container');
+    if (!overlay || !container) return;
     overlay.style.display = 'flex';
     if (!window._doomLoaded) {
       window._doomLoaded = true;
-      Dos(document.getElementById('doom-container'), {
+      Dos(container, {
         wdosboxUrl: themeUrl + '/js/vendor/wdosbox.js'
       }).run(themeUrl + '/js/vendor/doom.jsdos');
     }
   });
 
-  document.getElementById('close-doom').addEventListener('click', function () {
-    document.getElementById('doom-overlay').style.display = 'none';
-  });
+  var closeBtn = document.getElementById('close-doom');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', function () {
+      var overlay = document.getElementById('doom-overlay');
+      if (overlay) overlay.style.display = 'none';
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Avoid calling DOOM loader when overlay or container nodes are missing
- Skip close overlay logic if the close button is absent

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ad68aab6cc832cb423acc70d7ee7ba

## Summary by Sourcery

Guard against missing DOOM elements to prevent runtime errors when overlay, container, or close button nodes are not present.

Enhancements:
- Avoid initializing the DOOM loader if the overlay or container elements are missing
- Conditionally attach the close overlay handler only when the close button exists, skipping the logic otherwise