### PR TITLE
Fix DOOM overlay WAD URLs to avoid CORS

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,14 @@
  */
 
 
+if ( ! defined( 'NC_FREEDOOM_URL' ) ) {
+    define( 'NC_FREEDOOM_URL', 'https://raw.githubusercontent.com/freedoom/historic/trunk/0.6.4/freedoom2.wad' );
+}
+if ( ! defined( 'NC_SHAREWARE_URL' ) ) {
+    define( 'NC_SHAREWARE_URL', 'https://raw.githubusercontent.com/Akbar30Bill/DOOM_wads/master/doom1.wad' );
+}
+
+
 // Enable categories and tags for pages.
 function nc_enable_page_taxonomies() {
     register_taxonomy_for_object_type( 'category', 'page' );

--- a/page/functions.php
+++ b/page/functions.php
@@ -12,10 +12,10 @@
  */
 
 if ( ! defined( 'NC_FREEDOOM_URL' ) ) {
-    define( 'NC_FREEDOOM_URL', 'https://github.com/freedoom/historic/raw/refs/heads/trunk/0.6.4/freedoom2.wad' );
+    define( 'NC_FREEDOOM_URL', 'https://raw.githubusercontent.com/freedoom/historic/trunk/0.6.4/freedoom2.wad' );
 }
 if ( ! defined( 'NC_SHAREWARE_URL' ) ) {
-    define( 'NC_SHAREWARE_URL', 'https://github.com/Akbar30Bill/DOOM_wads/raw/refs/heads/master/doom1.wad' );
+    define( 'NC_SHAREWARE_URL', 'https://raw.githubusercontent.com/Akbar30Bill/DOOM_wads/master/doom1.wad' );
 }
 
 /**

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -76,6 +76,11 @@ class DoomOverlayTest extends TestCase {
         $this->assertSame('/path/theme/page/css/procrastinate.css', $path2);
     }
 
+    public function test_wad_urls_use_raw_github() {
+        $this->assertSame('raw.githubusercontent.com', parse_url(NC_FREEDOOM_URL, PHP_URL_HOST));
+        $this->assertSame('raw.githubusercontent.com', parse_url(NC_SHAREWARE_URL, PHP_URL_HOST));
+    }
+
     public function test_download_shareware_wad_extracts_file() {
         $tempDir = sys_get_temp_dir() . '/wadtest_' . uniqid();
         mkdir($tempDir);


### PR DESCRIPTION
## Summary
- Use raw.githubusercontent.com for bundled DOOM WAD downloads to satisfy CORS
- Verify WAD URLs target raw GitHub in unit tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ad83cb3b14832c9b55b239850143b8