### PR TITLE
Improve Doom overlay fullscreen and focus

### DIFF
--- a/page/assets/doom/engine/index.css
+++ b/page/assets/doom/engine/index.css
@@ -126,7 +126,7 @@ body {
   padding: 6px 20px;
   border-radius: 0;
   color: #00CC00;
-  
+
   font-weight: 300;
   font-size: 20px;
   cursor: pointer;
@@ -140,6 +140,7 @@ body {
 
   outline: 0;
   opacity: 0;
+  display: none;
 
   bottom: 0;
   top: 0;

--- a/page/assets/doom/overlay/doom-overlay.js
+++ b/page/assets/doom/overlay/doom-overlay.js
@@ -22,27 +22,47 @@
     function open(game) {
       wrap.hidden = false;
       const url = setGameParam(DOOM_OVERLAY_CFG.engineUrl, game || null);
-      if (frame.src !== url) frame.src = url;
+      if (frame.src !== url) {
+        frame.src = url;
+        frame.addEventListener('load', () => {
+          frame.focus();
+          frame.contentWindow?.focus();
+        }, { once: true });
+      } else {
+        frame.focus();
+        frame.contentWindow?.focus();
+      }
     }
 
     btn.addEventListener('click', () => open(DOOM_OVERLAY_CFG.gameFreedoom));
 
     btnFreedoom.addEventListener('click', () => {
       frame.src = setGameParam(DOOM_OVERLAY_CFG.engineUrl, DOOM_OVERLAY_CFG.gameFreedoom);
+      frame.addEventListener('load', () => {
+        frame.focus();
+        frame.contentWindow?.focus();
+      }, { once: true });
     });
 
     btnShare?.addEventListener('click', () => {
       frame.src = setGameParam(DOOM_OVERLAY_CFG.engineUrl, DOOM_OVERLAY_CFG.gameShareware);
+      frame.addEventListener('load', () => {
+        frame.focus();
+        frame.contentWindow?.focus();
+      }, { once: true });
     });
 
-    btnFS.addEventListener('click', async () => {
+    btnFS.addEventListener('click', () => {
       wrap.classList.toggle('full');
-      if (frame.requestFullscreen) frame.requestFullscreen().catch(() => {});
+      try {
+        frame.contentWindow.document.getElementById('fullscreen')?.click();
+      } catch (e) {}
     });
 
     btnClose.addEventListener('click', () => {
       wrap.hidden = true;
       frame.src = 'about:blank';
+      btn.focus();
     });
   });
 })();


### PR DESCRIPTION
## Summary
- Hide built-in emulator fullscreen button so only the game canvas is visible
- Custom fullscreen control triggers the emulator's internal fullscreen logic
- Focus moves to the game iframe when opened or switching games and returns to the trigger when closed

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ad91da0f8c832ca65a073192b74c4b