### PR TITLE
Fix keyboard input loss after entering Doom fullscreen

### DIFF
--- a/page/assets/doom/engine/index.js
+++ b/page/assets/doom/engine/index.js
@@ -32,6 +32,16 @@
 
     fullscreenButton.addEventListener('click', function () {
       Module.requestFullscreen(true, false);
+      // keep keyboard input active when toggling fullscreen
+      setTimeout(function () {
+        doomCanvas.focus();
+      }, 0);
+    });
+
+    document.addEventListener('fullscreenchange', function () {
+      if (document.fullscreenElement === doomCanvas) {
+        doomCanvas.focus();
+      }
     });
 
     return doomCanvas;


### PR DESCRIPTION
## Summary
- keep Doom emulator keyboard focus after toggling fullscreen by refocusing canvas
- ensure focus is restored whenever fullscreen state changes

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ad9587cefc832c892cf8add383ec84