### PR TITLE
feat(tools): install webDOOM build deps

### DIFF
--- a/tools/setup-webdoom.sh
+++ b/tools/setup-webdoom.sh
@@ -2,6 +2,37 @@
 # Build Freedoom WebAssembly engine assets without committing binaries.
 set -euo pipefail
 
+# Install build dependencies when missing. These are required by
+# the webDOOM project to compile its WebAssembly binaries.
+if ! command -v emcc >/dev/null 2>&1 || ! command -v autoheader >/dev/null 2>&1; then
+  echo "Installing webDOOM build dependencies..."
+  if command -v apt-get >/dev/null 2>&1; then
+    PKGS=(
+      build-essential
+      autoconf
+      automake
+      libtool
+      pkg-config
+      curl
+      git
+      unzip
+      emscripten
+    )
+    SUDO=""
+    if command -v sudo >/dev/null 2>&1; then
+      SUDO="sudo"
+    fi
+    $SUDO apt-get update
+    $SUDO apt-get install -y "${PKGS[@]}"
+  elif command -v brew >/dev/null 2>&1; then
+    brew update
+    brew install emscripten autoconf automake libtool pkg-config
+  else
+    echo "No supported package manager found. Please install emscripten, autoconf, automake, libtool and pkg-config." >&2
+    exit 1
+  fi
+fi
+
 DEST="$(dirname "$0")/../page/assets/doom/engine"
 TMP="$(mktemp -d)"
 


### PR DESCRIPTION
## Summary
- auto-install webDOOM build dependencies on demand so setup-webdoom works in fresh environments

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ada739cca0832c8e23420e2b854985

## Summary by Sourcery

Auto-install required build dependencies for webDOOM when running setup-webdoom.sh in fresh environments

New Features:
- Detect missing tools (emcc, autoheader) and install dependencies (emscripten, autoconf, automake, libtool, pkg-config, etc.) via apt-get or brew
- Error out with guidance if no supported package manager is found