### PR TITLE
Ensure SDL libraries installed for webDOOM build

### DIFF
--- a/tools/setup-webdoom.sh
+++ b/tools/setup-webdoom.sh
@@ -15,6 +15,7 @@ if ! command -v emcc >/dev/null 2>&1 || \
       automake
       libtool
       pkg-config
+      libsdl1.2-dev
       curl
       git
       unzip
@@ -28,9 +29,9 @@ if ! command -v emcc >/dev/null 2>&1 || \
     $SUDO apt-get install -y "${PKGS[@]}"
   elif command -v brew >/dev/null 2>&1; then
     brew update
-    brew install emscripten autoconf automake libtool pkg-config
+    brew install emscripten autoconf automake libtool pkg-config sdl
   else
-    echo "No supported package manager found. Please install emscripten, autoconf, automake, libtool and pkg-config." >&2
+    echo "No supported package manager found. Please install emscripten, autoconf, automake, libtool, pkg-config and SDL." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- install SDL development packages when building webDOOM assets

## Testing
- `composer install`
- `vendor/bin/phpunit`
- `bash -n tools/setup-webdoom.sh`


------
https://chatgpt.com/codex/tasks/task_e_68adb6674f2c832c86ddd6ddacc25f7a

## Summary by Sourcery

Ensure the webDOOM setup script installs the SDL development libraries on both Debian and macOS and updates the error message accordingly

Enhancements:
- Add libsdl1.2-dev to the apt package list for Debian-based installs
- Include sdl in the brew install command for macOS
- Update the error message to prompt installation of SDL when no supported package manager is found