### PR TITLE
Ensure webDOOM setup handles missing SDL macros

### DIFF
--- a/tools/setup-webdoom.sh
+++ b/tools/setup-webdoom.sh
@@ -75,6 +75,8 @@ AC_DEFUN([AM_PATH_SDL], [
   SDL_CFLAGS=""
   SDL_LIBS=""
   sdl_main=yes
+  AC_SUBST([SDL_CFLAGS])
+  AC_SUBST([SDL_LIBS])
 ])
 EOF
 fi


### PR DESCRIPTION
## Summary
- Expand stubbed `AM_PATH_SDL` macro with `AC_SUBST` directives so Autotools replaces SDL flags correctly

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68adbeb2f00c832c8f709053a9f303e2

## Summary by Sourcery

Build:
- Add AC_SUBST directives for SDL_CFLAGS and SDL_LIBS in the AM_PATH_SDL stub macro to ensure Autotools correctly substitutes SDL flags