### PR TITLE
Update WebDOOM setup for modern wasm config

### DIFF
--- a/tools/setup-webdoom.sh
+++ b/tools/setup-webdoom.sh
@@ -115,6 +115,14 @@ mv "$TMP/freedoom2.wad" "$TMP/webDOOM/build/doom2.wad"
 pushd "$TMP/webDOOM" >/dev/null
 # Regenerate autotools files for the local environment
 ./bootstrap
+
+# Replace outdated config.guess and config.sub with modern versions that
+# recognize the wasm32-unknown-emscripten target. The versions shipped in the
+# upstream repository predate WebAssembly support, causing `configure` to abort
+# when passed the `--host=wasm32-unknown-emscripten` triple.
+curl -L https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD -o autotools/config.sub
+curl -L https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD -o autotools/config.guess
+chmod +x autotools/config.sub autotools/config.guess
 # Explicitly set the host triple so Autoconf treats the build as a cross
 # compilation targeting WebAssembly and skips executing test binaries, which
 # would fail under Emscripten when Node.js is unavailable.


### PR DESCRIPTION
## Summary
- Refresh webDOOM's config.guess and config.sub to recognize the `wasm32-unknown-emscripten` host

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68adc431b738832cb9a9557b25239798

## Summary by Sourcery

Build:
- Replace outdated config.sub and config.guess with the latest versions from GNU’s config repository to support the wasm32-unknown-emscripten target in the setup-webdoom.sh script