### PR TITLE
Quote config URLs in setup-webdoom script

### DIFF
--- a/tools/setup-webdoom.sh
+++ b/tools/setup-webdoom.sh
@@ -120,8 +120,8 @@ pushd "$TMP/webDOOM" >/dev/null
 # recognize the wasm32-unknown-emscripten target. The versions shipped in the
 # upstream repository predate WebAssembly support, causing `configure` to abort
 # when passed the `--host=wasm32-unknown-emscripten` triple.
-curl -L https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD -o autotools/config.sub
-curl -L https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD -o autotools/config.guess
+curl -L "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" -o autotools/config.sub
+curl -L "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" -o autotools/config.guess
 chmod +x autotools/config.sub autotools/config.guess
 # Explicitly set the host triple so Autoconf treats the build as a cross
 # compilation targeting WebAssembly and skips executing test binaries, which


### PR DESCRIPTION
## Summary
- prevent shell from treating config.git URLs as background commands by quoting them in setup-webdoom.sh

## Testing
- `vendor/bin/phpunit`
- `command -v shellcheck >/dev/null 2>&1 && shellcheck tools/setup-webdoom.sh`

------
https://chatgpt.com/codex/tasks/task_e_68adc5e9cae8832c9b578460f800f2db

## Summary by Sourcery

Bug Fixes:
- Wrap config.git URL arguments in double quotes for curl commands in setup-webdoom.sh