### PR TITLE
Switch DOOM overlay to WebPrBoom engine

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -71,11 +71,13 @@ if ( ! function_exists( 'nc_enqueue_doom_overlay_assets' ) ) {
         wp_enqueue_style( 'doom-overlay', nc_theme_file_uri( $css_rel ), array(), $css_ver );
         wp_enqueue_script( 'doom-overlay', nc_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
 
-        wp_localize_script( 'doom-overlay', 'DOOM_OVERLAY_CFG', array(
-            'engineUrl' => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
-            'gamePhase1' => 'freedoom1',
-            'gamePhase2' => 'freedoom2',
-        ) );
+        wp_localize_script(
+            'doom-overlay',
+            'DOOM_OVERLAY_CFG',
+            array(
+                'engineUrl' => 'https://raz0red.github.io/webprboom/',
+            )
+        );
     }
     add_action( 'wp_enqueue_scripts', 'nc_enqueue_doom_overlay_assets' );
 }
@@ -91,8 +93,6 @@ if ( ! function_exists( 'nc_render_doom_overlay' ) ) {
                 <div class="doom-bar">
                     <span class="doom-title">DOOM</span>
                     <div class="doom-spacer"></div>
-                    <button class="doom-iwad doom-iwad-phase1">Freedoom Phase 1</button>
-                    <button class="doom-iwad doom-iwad-phase2">Freedoom Phase 2</button>
                     <button class="doom-fullscreen">Fullscreen</button>
                     <button class="doom-close" aria-label="Close">✕</button>
                 </div>

--- a/page/assets/doom/overlay/doom-overlay.js
+++ b/page/assets/doom/overlay/doom-overlay.js
@@ -1,14 +1,6 @@
 (function () {
   const qs = (s, r = document) => r.querySelector(s);
 
-  function setGameParam(url, game) {
-    try {
-      const u = new URL(url, window.location.origin);
-      if (game) u.searchParams.set('game', game);
-      return u.toString();
-    } catch { return url; }
-  }
-
   document.addEventListener('DOMContentLoaded', () => {
     const root  = qs('#doom-procrastinate');
     const btn   = qs('.doom-open', root);
@@ -16,8 +8,6 @@
     const frame = qs('#doom-frame', root);
     const btnFS = qs('.doom-fullscreen', root);
     const btnClose = qs('.doom-close', root);
-    const btnPhase1 = qs('.doom-iwad-phase1', root);
-    const btnPhase2 = qs('.doom-iwad-phase2', root);
 
     let lastFocus = null;
 
@@ -28,41 +18,19 @@
     }
 
     function fixFrame() {
-      const doc = frame.contentDocument;
-      if (!doc) return;
-      doc.getElementById('fullscreen')?.style.setProperty('display', 'none');
-      doc.getElementById('preview')?.style.setProperty('display', 'none');
-      const canvas = doc.getElementById('doom');
-      if (canvas) {
-        canvas.style.left = '0';
-        canvas.style.right = '0';
-        canvas.style.width = '100%';
-        canvas.style.height = '100%';
-      }
-      doc.addEventListener('fullscreenchange', focusFrame);
       focusFrame();
     }
     frame.addEventListener('load', fixFrame);
 
-    function open(game) {
+    function open() {
       lastFocus = document.activeElement;
       wrap.hidden = false;
-      const url = setGameParam(DOOM_OVERLAY_CFG.engineUrl, game || null);
+      const url = DOOM_OVERLAY_CFG.engineUrl;
       if (frame.src !== url) frame.src = url;
       frame.focus();
     }
 
-    btn.addEventListener('click', () => open(DOOM_OVERLAY_CFG.gamePhase2));
-
-    btnPhase1.addEventListener('click', () => {
-      frame.src = setGameParam(DOOM_OVERLAY_CFG.engineUrl, DOOM_OVERLAY_CFG.gamePhase1);
-      frame.focus();
-    });
-
-    btnPhase2.addEventListener('click', () => {
-      frame.src = setGameParam(DOOM_OVERLAY_CFG.engineUrl, DOOM_OVERLAY_CFG.gamePhase2);
-      frame.focus();
-    });
+    btn.addEventListener('click', open);
 
     btnFS.addEventListener('click', () => {
       const fs = frame.contentDocument?.getElementById('fullscreen');

--- a/page/functions.php
+++ b/page/functions.php
@@ -790,11 +790,13 @@ function nc_enqueue_doom_overlay_assets() {
     wp_enqueue_style( 'doom-overlay', nc_theme_file_uri( $css_rel ), array(), $css_ver );
     wp_enqueue_script( 'doom-overlay', nc_theme_file_uri( $js_rel ), array( 'jquery' ), $js_ver, true );
 
-    wp_localize_script( 'doom-overlay', 'DOOM_OVERLAY_CFG', array(
-        'engineUrl' => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
-        'gamePhase1' => 'freedoom1',
-        'gamePhase2' => 'freedoom2',
-    ) );
+    wp_localize_script(
+        'doom-overlay',
+        'DOOM_OVERLAY_CFG',
+        array(
+            'engineUrl' => 'https://raz0red.github.io/webprboom/',
+        )
+    );
 }
 add_action( 'wp_enqueue_scripts', 'nc_enqueue_doom_overlay_assets' );
 
@@ -808,8 +810,6 @@ function nc_render_doom_overlay() {
             <div class="doom-bar">
                 <span class="doom-title">DOOM</span>
                 <div class="doom-spacer"></div>
-                <button class="doom-iwad doom-iwad-phase1">Freedoom Phase 1</button>
-                <button class="doom-iwad doom-iwad-phase2">Freedoom Phase 2</button>
                 <button class="doom-fullscreen">Fullscreen</button>
                 <button class="doom-close" aria-label="Close">✕</button>
             </div>

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -17,19 +17,16 @@ class DoomOverlayTest extends TestCase {
 
         $themeUri = 'http://example.com/theme/page';
 
-        Monkey\Functions\expect('get_stylesheet_directory')->times(5)->andReturn('/path/theme/page');
+        Monkey\Functions\expect('get_stylesheet_directory')->times(4)->andReturn('/path/theme/page');
         Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn($themeUri . '/assets/doom/overlay/doom-overlay.css');
         Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/overlay/doom-overlay.js')->andReturn($themeUri . '/assets/doom/overlay/doom-overlay.js');
-        Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/engine/index.html')->andReturn($themeUri . '/assets/doom/engine/index.html');
         Monkey\Functions\expect('get_theme_file_path')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn($tempDir . '/assets/doom/overlay/doom-overlay.css');
         Monkey\Functions\expect('get_theme_file_path')->once()->with('assets/doom/overlay/doom-overlay.js')->andReturn($tempDir . '/assets/doom/overlay/doom-overlay.js');
 
         Monkey\Functions\expect('wp_enqueue_style')->once()->with('doom-overlay', $themeUri . '/assets/doom/overlay/doom-overlay.css', [], $cssMtime);
         Monkey\Functions\expect('wp_enqueue_script')->once()->with('doom-overlay', $themeUri . '/assets/doom/overlay/doom-overlay.js', ['jquery'], $jsMtime, true);
         Monkey\Functions\expect('wp_localize_script')->once()->with('doom-overlay', 'DOOM_OVERLAY_CFG', [
-            'engineUrl' => $themeUri . '/assets/doom/engine/index.html',
-            'gamePhase1' => 'freedoom1',
-            'gamePhase2' => 'freedoom2',
+            'engineUrl' => 'https://raz0red.github.io/webprboom/',
         ]);
 
         nc_enqueue_doom_overlay_assets();
@@ -48,8 +45,8 @@ class DoomOverlayTest extends TestCase {
         nc_render_doom_overlay();
         $out = ob_get_clean();
         $this->assertStringContainsString('id="doom-procrastinate"', $out);
-        $this->assertStringContainsString('doom-iwad-phase1', $out);
-        $this->assertStringContainsString('doom-iwad-phase2', $out);
+        $this->assertStringNotContainsString('doom-iwad-phase1', $out);
+        $this->assertStringNotContainsString('doom-iwad-phase2', $out);
     }
 
     public function test_theme_file_helpers_resolve_paths() {


### PR DESCRIPTION
## Summary
- Load DOOM overlay from the WebPrBoom engine hosted on GitHub instead of bundled Freedoom assets
- Simplify overlay script and markup by removing IWAD selection buttons
- Update tests to reflect new engine location and streamlined overlay

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68af413349f8832c9d1b1398961a7939

## Summary by Sourcery

Switch the DOOM overlay to the WebPrBoom engine, remove Freedoom IWAD selection, simplify the overlay script and markup, and update tests to match the new configuration.

Enhancements:
- Replace bundled Freedoom assets with an external WebPrBoom engine URL for the DOOM overlay
- Remove IWAD selection buttons and related game-parameter logic from the overlay script and markup
- Streamline overlay initialization by removing URL parameter handling
- Update script localization to provide only the engine URL

Tests:
- Adjust asset-enqueue tests to expect the external engine URL
- Remove tests for the removed IWAD buttons and gamePhase parameters