### PR TITLE
Add Doom IWAD selector and enable fullscreen

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -92,6 +92,11 @@ if ( ! function_exists( 'nc_render_doom_overlay' ) ) {
             <div id="doom-frame-wrap" hidden>
                 <div class="doom-bar">
                     <span class="doom-title">DOOM</span>
+                    <select class="doom-iwad" aria-label="Select game">
+                        <option value="doom1">Doom Shareware</option>
+                        <option value="freedoom1">Freedoom 1</option>
+                        <option value="freedoom2">Freedoom 2</option>
+                    </select>
                     <div class="doom-spacer"></div>
                     <button class="doom-fullscreen">Fullscreen</button>
                     <button class="doom-close" aria-label="Close">✕</button>

--- a/page/assets/doom/engine/index.js
+++ b/page/assets/doom/engine/index.js
@@ -100,7 +100,7 @@
 
     var params = new URLSearchParams(window.location.search);
     var autoGame = params.get('game');
-    if (autoGame === 'freedoom1' || autoGame === 'freedoom2') {
+    if (autoGame === 'doom1' || autoGame === 'freedoom1' || autoGame === 'freedoom2') {
       onGameClick(autoGame);
     }
   });

--- a/page/assets/doom/overlay/doom-overlay.js
+++ b/page/assets/doom/overlay/doom-overlay.js
@@ -8,6 +8,7 @@
     const frame = qs('#doom-frame', root);
     const btnFS = qs('.doom-fullscreen', root);
     const btnClose = qs('.doom-close', root);
+    const selIwad = qs('.doom-iwad', root);
 
     let lastFocus = null;
 
@@ -25,16 +26,22 @@
     function open() {
       lastFocus = document.activeElement;
       wrap.hidden = false;
-      const url = DOOM_OVERLAY_CFG.engineUrl;
-      if (frame.src !== url) frame.src = url;
+      const game = encodeURIComponent(selIwad.value);
+      const url = DOOM_OVERLAY_CFG.engineUrl + '?game=' + game;
+      frame.src = url;
       frame.focus();
     }
 
     btn.addEventListener('click', open);
 
     btnFS.addEventListener('click', () => {
-      const fs = frame.contentDocument?.getElementById('fullscreen');
-      fs?.click();
+      const mod = frame.contentWindow?.Module;
+      if (typeof mod?.requestFullscreen === 'function') {
+        mod.requestFullscreen(true, false);
+      } else {
+        const fs = frame.contentDocument?.getElementById('fullscreen');
+        fs?.click();
+      }
       focusFrame();
     });
 

--- a/page/functions.php
+++ b/page/functions.php
@@ -809,6 +809,11 @@ function nc_render_doom_overlay() {
         <div id="doom-frame-wrap" hidden>
             <div class="doom-bar">
                 <span class="doom-title">DOOM</span>
+                <select class="doom-iwad" aria-label="Select game">
+                    <option value="doom1">Doom Shareware</option>
+                    <option value="freedoom1">Freedoom 1</option>
+                    <option value="freedoom2">Freedoom 2</option>
+                </select>
                 <div class="doom-spacer"></div>
                 <button class="doom-fullscreen">Fullscreen</button>
                 <button class="doom-close" aria-label="Close">✕</button>

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -45,8 +45,10 @@ class DoomOverlayTest extends TestCase {
         nc_render_doom_overlay();
         $out = ob_get_clean();
         $this->assertStringContainsString('id="doom-procrastinate"', $out);
-        $this->assertStringNotContainsString('doom-iwad-phase1', $out);
-        $this->assertStringNotContainsString('doom-iwad-phase2', $out);
+        $this->assertStringContainsString('class="doom-iwad"', $out);
+        $this->assertStringContainsString('value="doom1"', $out);
+        $this->assertStringContainsString('value="freedoom1"', $out);
+        $this->assertStringContainsString('value="freedoom2"', $out);
     }
 
     public function test_theme_file_helpers_resolve_paths() {


### PR DESCRIPTION
## Summary
- Add IWAD dropdown to pick Doom shareware or Freedoom episodes
- Start selected game immediately when procrastination overlay opens
- Hook fullscreen button to emulator's fullscreen API when available

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68af46f846bc832c908b05354bc27d6a