### PR TITLE
Serve DOOM engine locally and enable game switching

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -75,7 +75,7 @@ if ( ! function_exists( 'nc_enqueue_doom_overlay_assets' ) ) {
             'doom-overlay',
             'DOOM_OVERLAY_CFG',
             array(
-                'engineUrl' => 'https://raz0red.github.io/webprboom/',
+                'engineUrl' => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
             )
         );
     }

--- a/page/assets/doom/overlay/doom-overlay.js
+++ b/page/assets/doom/overlay/doom-overlay.js
@@ -34,6 +34,12 @@
 
     btn.addEventListener('click', open);
 
+    selIwad.addEventListener('change', () => {
+      const game = encodeURIComponent(selIwad.value);
+      frame.src = DOOM_OVERLAY_CFG.engineUrl + '?game=' + game;
+      focusFrame();
+    });
+
     btnFS.addEventListener('click', () => {
       const mod = frame.contentWindow?.Module;
       if (typeof mod?.requestFullscreen === 'function') {

--- a/page/functions.php
+++ b/page/functions.php
@@ -794,7 +794,7 @@ function nc_enqueue_doom_overlay_assets() {
         'doom-overlay',
         'DOOM_OVERLAY_CFG',
         array(
-            'engineUrl' => 'https://raz0red.github.io/webprboom/',
+            'engineUrl' => nc_theme_file_uri( 'assets/doom/engine/index.html' ),
         )
     );
 }

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -17,16 +17,17 @@ class DoomOverlayTest extends TestCase {
 
         $themeUri = 'http://example.com/theme/page';
 
-        Monkey\Functions\expect('get_stylesheet_directory')->times(4)->andReturn('/path/theme/page');
+        Monkey\Functions\expect('get_stylesheet_directory')->times(5)->andReturn('/path/theme/page');
         Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn($themeUri . '/assets/doom/overlay/doom-overlay.css');
         Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/overlay/doom-overlay.js')->andReturn($themeUri . '/assets/doom/overlay/doom-overlay.js');
+        Monkey\Functions\expect('get_theme_file_uri')->once()->with('assets/doom/engine/index.html')->andReturn($themeUri . '/assets/doom/engine/index.html');
         Monkey\Functions\expect('get_theme_file_path')->once()->with('assets/doom/overlay/doom-overlay.css')->andReturn($tempDir . '/assets/doom/overlay/doom-overlay.css');
         Monkey\Functions\expect('get_theme_file_path')->once()->with('assets/doom/overlay/doom-overlay.js')->andReturn($tempDir . '/assets/doom/overlay/doom-overlay.js');
 
         Monkey\Functions\expect('wp_enqueue_style')->once()->with('doom-overlay', $themeUri . '/assets/doom/overlay/doom-overlay.css', [], $cssMtime);
         Monkey\Functions\expect('wp_enqueue_script')->once()->with('doom-overlay', $themeUri . '/assets/doom/overlay/doom-overlay.js', ['jquery'], $jsMtime, true);
         Monkey\Functions\expect('wp_localize_script')->once()->with('doom-overlay', 'DOOM_OVERLAY_CFG', [
-            'engineUrl' => 'https://raz0red.github.io/webprboom/',
+            'engineUrl' => $themeUri . '/assets/doom/engine/index.html',
         ]);
 
         nc_enqueue_doom_overlay_assets();


### PR DESCRIPTION
## Summary
- Load DOOM engine from local theme assets so fullscreen works
- Reload engine when IWAD selector changes
- Update tests for new engine URL

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68af4ea6e34c832ca44173b81ab8461e