### PR TITLE
Show USK warning as popup for Doom overlay

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -87,8 +87,8 @@ if ( ! function_exists( 'nc_render_doom_overlay' ) ) {
     function nc_render_doom_overlay() {
         ?>
         <div id="doom-procrastinate">
-            <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap">Procrastinate <span class="doom-here">here!</span></button>
-            <p class="doom-rating">USK 16 – not for under 16s. Nicht für unter 16-Jährige.</p>
+            <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap" aria-describedby="doom-usk">Procrastinate <span class="doom-here">here!</span></button>
+            <p id="doom-usk" class="doom-rating" hidden>USK 16 – not for under 16s. Nicht für unter 16-Jährige.</p>
 
             <div id="doom-frame-wrap" hidden>
                 <div class="doom-bar">

--- a/page/assets/doom/overlay/doom-overlay.css
+++ b/page/assets/doom/overlay/doom-overlay.css
@@ -19,5 +19,16 @@
 #doom-frame { width: 100%; height: calc(100% - 28px); border: 0; display: block; }
 .doom-fullscreen, .doom-close { background: #2c2c2c; color:#eee; border:0; padding:.25rem .5rem; border-radius:.35rem; cursor:pointer; }
 #doom-procrastinate .doom-rating {
-  margin-top: .5rem; color: #eee; font: 500 12px/1.2 system-ui, sans-serif;
+  position: absolute;
+  top: calc(100% + .5rem);
+  right: 0;
+  width: 240px;
+  padding: .5rem;
+  background: #111;
+  color: #eee;
+  font: 500 12px/1.2 system-ui, sans-serif;
+  border-radius: .5rem;
+  box-shadow: 0 2px 12px rgba(0,0,0,.25);
 }
+
+#doom-procrastinate .doom-rating[hidden] { display: none; }

--- a/page/assets/doom/overlay/doom-overlay.js
+++ b/page/assets/doom/overlay/doom-overlay.js
@@ -4,10 +4,11 @@
   document.addEventListener('DOMContentLoaded', () => {
     const root  = qs('#doom-procrastinate');
     const btn   = qs('.doom-open', root);
-    const wrap  = qs('#doom-frame-wrap', root);
-    const frame = qs('#doom-frame', root);
-    const btnFS = qs('.doom-fullscreen', root);
+    const wrap   = qs('#doom-frame-wrap', root);
+    const frame  = qs('#doom-frame', root);
+    const btnFS  = qs('.doom-fullscreen', root);
     const btnClose = qs('.doom-close', root);
+    const rating = qs('.doom-rating', root);
 
     let lastFocus = null;
 
@@ -22,7 +23,23 @@
     }
     frame.addEventListener('load', fixFrame);
 
+    function showRating() {
+      if (rating) { rating.hidden = false; }
+    }
+
+    function hideRating() {
+      if (rating) { rating.hidden = true; }
+    }
+
+    if (rating) {
+      btn.addEventListener('mouseenter', showRating);
+      btn.addEventListener('mouseleave', hideRating);
+      btn.addEventListener('focus', showRating);
+      btn.addEventListener('blur', hideRating);
+    }
+
     function open() {
+      hideRating();
       lastFocus = document.activeElement;
       wrap.hidden = false;
       frame.src = DOOM_OVERLAY_CFG.engineUrl;

--- a/tests/DoomOverlayTest.php
+++ b/tests/DoomOverlayTest.php
@@ -48,6 +48,9 @@ class DoomOverlayTest extends TestCase {
         $this->assertStringContainsString('id="doom-procrastinate"', $out);
         $this->assertStringContainsString('USK 16', $out);
         $this->assertStringContainsString('doom-fullscreen', $out);
+        $this->assertStringContainsString('aria-describedby="doom-usk"', $out);
+        $this->assertStringContainsString('id="doom-usk"', $out);
+        $this->assertStringContainsString('class="doom-rating" hidden', $out);
     }
 
     public function test_theme_file_helpers_resolve_paths() {


### PR DESCRIPTION
## Summary
- Hide USK rating text by default and attach to Procrastinate button via aria-describedby.
- Style and toggle rating as an overlay that appears on button focus or hover.
- Extend tests to cover the new hidden USK markup.

## Testing
- `composer install --no-interaction --no-progress`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68af729bd6fc832c8ff4e43b17ab0343