### PR TITLE
Hide USK rating until user interacts

### DIFF
--- a/page/functions.php
+++ b/page/functions.php
@@ -804,8 +804,8 @@ add_action( 'wp_enqueue_scripts', 'nc_enqueue_doom_overlay_assets' );
 function nc_render_doom_overlay() {
     ?>
     <div id="doom-procrastinate">
-        <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap">Procrastinate <span class="doom-here">here!</span></button>
-        <p class="doom-rating">USK 16 – not for under 16s. Nicht für unter 16-Jährige.</p>
+        <button class="doom-open" aria-haspopup="dialog" aria-controls="doom-frame-wrap" aria-describedby="doom-usk">Procrastinate <span class="doom-here">here!</span></button>
+        <p id="doom-usk" class="doom-rating" hidden>USK 16 – not for under 16s. Nicht für unter 16-Jährige.</p>
 
         <div id="doom-frame-wrap" hidden>
             <div class="doom-bar">


### PR DESCRIPTION
## Summary
- Prevent USK 16 rating text from showing on initial load by defaulting it to hidden
- Link overlay trigger to rating text for accessibility via aria-describedby

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68af76bcff2c832ca521c5fdff1c0574

## Summary by Sourcery

Hide the USK rating by default and link the overlay trigger to it for accessibility

Enhancements:
- Default the USK rating text to hidden until user interaction
- Add aria-describedby on the overlay trigger button to reference the rating text